### PR TITLE
Updating dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Updated the dockerfile to remove apt-get
+
 ## 1.3.0 2018-06-27
 - Move SDX queues from EQ cluster to AWS corp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ COPY requirements.txt /requirements.txt
 COPY startup.sh /startup.sh
 COPY Makefile /Makefile
 
-RUN apt-get update -y
-RUN apt-get upgrade -y
-RUN apt-get install -yq git gcc make build-essential python3-dev python3-reportlab
 RUN make build
 
 WORKDIR app


### PR DESCRIPTION
## What? and Why?
When building the image from sdx-gateway, an error was occurring when trying to run `apt-get update`. After talking with Adam, we realised that we don't actually need the apt-get that the dockerfile does so we've removed it.

## Test
- The best way to test is to purge your docker and rebuild the images
