### PR TITLE
Exposing port 8087 for sdx-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-
+- Exposing port 8087 for docker
 - Updated the dockerfile to remove apt-get
 
 ## 1.3.0 2018-06-27

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,6 @@ RUN make build
 
 WORKDIR app
 
+EXPOSE 8087
+
 ENTRYPOINT python3 -m app.main

--- a/app/main.py
+++ b/app/main.py
@@ -213,7 +213,7 @@ def main():
 
     app = make_app()
     server = tornado.httpserver.HTTPServer(app)
-    server.bind(int(os.getenv("SDX_GATEWAY_PORT", '8080')))
+    server.bind(int(os.getenv("SDX_GATEWAY_PORT", '8087')))
     server.start(1)
     bridge = Bridge()
 


### PR DESCRIPTION
## What has changed
Currently the healthcheck endpoint in sdx-gatway cannot not be accessed when running in the dev environment. This PR exposing its port so it the healthcheck endpoint can be accessed.

## Test
- Run the tests
- Run with the rest of the services and the [sdx-compose pr ](https://github.com/ONSdigital/sdx-compose/pull/65)to make sure it all works correctly
- try going to `localhost:8087/healthcheck` and you should be able to hit the gateways healthcheck endpoint