### PR TITLE
Remove healthcheck

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -130,10 +130,6 @@ class GetHealth:
                 self._default_user,
                 self._default_pass,
                 self._rabbit_hosts[1]),
-            'http://{}:{}@{}:15672/api/healthchecks/node'.format(
-                settings.SDX_GATEWAY_SDX_RABBITMQ_USER,
-                settings.SDX_GATEWAY_SDX_RABBITMQ_PASSWORD,
-                settings.SDX_GATEWAY_SDX_RABBITMQ_HOST),
         ]
 
     @gen.coroutine

--- a/app/main.py
+++ b/app/main.py
@@ -130,6 +130,10 @@ class GetHealth:
                 self._default_user,
                 self._default_pass,
                 self._rabbit_hosts[1]),
+            'http://{}:{}@{}:15672/api/healthchecks/node'.format(
+                settings.SDX_GATEWAY_SDX_RABBITMQ_USER,
+                settings.SDX_GATEWAY_SDX_RABBITMQ_PASSWORD,
+                settings.SDX_GATEWAY_SDX_RABBITMQ_HOST),
         ]
 
     @gen.coroutine
@@ -137,7 +141,7 @@ class GetHealth:
         logger.info("Starting to check rabbit health")
         for url in self.rabbit_urls:
             try:
-                logger.info("Fetching rabbit health")
+                logger.info("Fetching rabbit health", url=url)
                 response = yield AsyncHTTPClient().fetch(url)
             except HTTPError:
                 logger.exception("Error receiving rabbit health")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,11 +120,6 @@ class TestGetHealth(unittest.TestCase):
             settings.SDX_GATEWAY_EQ_RABBITMQ_PASSWORD,
             settings.SDX_GATEWAY_EQ_RABBITMQ_HOST2,
         ),
-        'http://{}:{}@{}:15672/api/healthchecks/node'.format(
-            settings.SDX_GATEWAY_SDX_RABBITMQ_USER,
-            settings.SDX_GATEWAY_SDX_RABBITMQ_PASSWORD,
-            settings.SDX_GATEWAY_SDX_RABBITMQ_HOST,
-        ),
     ]
 
     def test_get_health_settings(self):


### PR DESCRIPTION
The healthcheck is failing in preprod because we haven't got the right credentials.  

Removing this for now so we can get connection info between us and eq for now until the issue is sorted